### PR TITLE
fix(pdf-core): harden FlateDecode and xref/startxref recovery

### DIFF
--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -189,12 +189,14 @@ endstream
     }
 
     /**
-     * Decompress FlateDecode stream by format-aware detection (RFC 1950, 1951, 1952).
+     * Decompress FlateDecode stream using a waterfall of RFC 1950/1951/1952 methods.
      *
      * ISO 32000 mandates zlib (RFC 1950), but non-conforming generators produce raw deflate
-     * (RFC 1951) or gzip (RFC 1952). Each format has a deterministic byte signature:
-     * gzip (0x1F 0x8B) → gzdecode(), zlib (CMF header checksum) → gzuncompress(),
-     * everything else → gzinflate(). This avoids blind trial-and-error.
+     * (RFC 1951) or gzip (RFC 1952). We detect the most likely format from the header bytes
+     * and try that first, then fall through to the remaining methods before giving up.
+     * This handles cases where the header passes a format check but the data decompresses
+     * correctly with a different codec (e.g. zlib header bytes coincidentally valid but
+     * the payload is raw deflate).
      *
      * @throws PdfCoreParsingException
      */
@@ -203,28 +205,22 @@ endstream
         $b0 = strlen($stream) > 1 ? ord($stream[0]) : -1;
         $b1 = strlen($stream) > 1 ? ord($stream[1]) : -1;
 
-        // Gzip: magic bytes 0x1F 0x8B (RFC 1952).
+        // Gzip: magic bytes 0x1F 0x8B (RFC 1952). Try first when headers match.
         if ($b0 === 0x1F && $b1 === 0x8B) {
             $inflated = @gzdecode($stream);
             if (is_string($inflated)) {
                 return $inflated;
             }
-
-            throw new PdfCoreParsingException('Failed to inflate FlateDecode stream.');
+            // Fall through — misdetected gzip header; try other codecs below.
         }
 
-        // zlib: CMF+FLG header where (CMF*256+FLG) % 31 === 0 and CM (lower 4
-        // bits of CMF) === 8 (deflate). (RFC 1950)
-        if ($b0 !== -1 && ($b0 & 0x0F) === 8 && ($b0 * 256 + $b1) % 31 === 0) {
-            $inflated = @gzuncompress($stream);
-            if (is_string($inflated)) {
-                return $inflated;
-            }
-
-            throw new PdfCoreParsingException('Failed to inflate FlateDecode stream.');
+        // zlib (RFC 1950): works for conforming PDF generators and some edge cases.
+        $inflated = @gzuncompress($stream);
+        if (is_string($inflated)) {
+            return $inflated;
         }
 
-        // Raw deflate (RFC 1951): no wrapper header.
+        // Raw deflate (RFC 1951): no wrapper header; fallback for non-conforming generators.
         $inflated = @gzinflate($stream);
         if (is_string($inflated)) {
             return $inflated;

--- a/src/Infrastructure/PdfCore/Struct.php
+++ b/src/Infrastructure/PdfCore/Struct.php
@@ -65,16 +65,11 @@ class Struct
             $versions[] = intval($match[2][1]) + strlen($match[2][0]);
         }
 
-        $startXRefPos = strrpos($buffer, 'startxref');
-        if ($startXRefPos === false) {
+        $xrefPos = $this->resolveXrefPosition($buffer);
+
+        if ($xrefPos === null) {
             throw new Exception('startxref not found');
         }
-
-        if (preg_match('/startxref\s*([0-9]+)\s*%%EOF\s*$/ms', $buffer, $matches, 0, $startXRefPos) !== 1) {
-            throw new Exception('startxref and %%EOF not found');
-        }
-
-        $xrefPos = intval($matches[1]);
 
         if ($xrefPos === 0) {
             return new ParsedDocumentStructure(
@@ -100,5 +95,62 @@ class Struct
             xrefVersion: $xref->minimumPdfVersion,
             revisions: $versions,
         );
+    }
+
+    /**
+     * Resolve the xref table position from the PDF buffer.
+     *
+     * Strategy (in order):
+     *  1. Parse `startxref <offset> %%EOF` (ISO 32000 §7.5.5, strict form).
+     *  2. Parse `startxref <offset>` without `%%EOF` (lenient -- handles truncated trailers).
+     *  3. Scan backward from EOF for the last standalone `xref` keyword
+     *     (handles PDFs where `startxref` is absent or carries no valid offset).
+     *
+     * Returns null only when all three strategies yield nothing, allowing callers
+     * to throw a meaningful exception.
+     */
+    private function resolveXrefPosition(string $buffer): ?int
+    {
+        $startXRefPos = strrpos($buffer, 'startxref');
+
+        if ($startXRefPos !== false) {
+            // Strict form: startxref <offset> %%EOF
+            if (preg_match('/startxref\s*([0-9]+)\s*%%EOF\s*$/ms', $buffer, $matches, 0, $startXRefPos) === 1) {
+                return intval($matches[1]);
+            }
+
+            // Lenient form: startxref <offset> (no %%EOF -- truncated or malformed trailer)
+            if (preg_match('/startxref\s*([0-9]+)/ms', $buffer, $matches, 0, $startXRefPos) === 1) {
+                return intval($matches[1]);
+            }
+        }
+
+        // Last resort: no valid startxref offset found. Scan backward for the last
+        // standalone 'xref' keyword so we can locate the xref table directly.
+        return $this->findLastStandaloneXref($buffer);
+    }
+
+    /**
+     * Scan backward from EOF for the last standalone `xref` keyword (preceded by a newline).
+     * Also handles `xref` at the very start of the buffer (no preceding newline).
+     * Returns the byte offset of the `x` in `xref`, or null if not found.
+     */
+    private function findLastStandaloneXref(string $buffer): ?int
+    {
+        foreach (["\nxref\n", "\nxref\r\n", "\r\nxref\n", "\r\nxref\r\n"] as $needle) {
+            $pos = strrpos($buffer, $needle);
+            if ($pos !== false) {
+                return $pos + 1; // skip the leading newline; point at 'x'
+            }
+        }
+
+        // Also handle 'xref' at the very start of the buffer (no preceding newline).
+        foreach (["xref\n", "xref\r\n"] as $needle) {
+            if (str_starts_with($buffer, $needle)) {
+                return 0;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Infrastructure/PdfCore/Xref/Service/XRef14Parser.php
+++ b/src/Infrastructure/PdfCore/Xref/Service/XRef14Parser.php
@@ -19,7 +19,13 @@ final class XRef14Parser
     public function parse(string $buffer, int $xrefPosition, array $visitedPositions = []): XrefParseResult
     {
         if ($xrefPosition > strlen($buffer)) {
-            throw new PdfCoreParsingException('Xref position '.$xrefPosition.' is beyond end of file');
+            // Reported offset is beyond EOF (stale/wrong startxref value).
+            // Scan backward from the end of the file for the last standalone 'xref' table.
+            $fallback = $this->findLastXrefByScanning($buffer);
+            if ($fallback === null) {
+                throw new PdfCoreParsingException('Xref position '.$xrefPosition.' is beyond end of file');
+            }
+            $xrefPosition = $fallback;
         }
 
         $trailerPosition = strpos($buffer, 'trailer', $xrefPosition);
@@ -28,7 +34,13 @@ final class XRef14Parser
         }
 
         $version = '1.4';
-        $xrefText = substr($buffer, $xrefPosition, $trailerPosition - $xrefPosition);
+
+        // Expand the window up to 512 bytes before $xrefPosition to handle generators
+        // that emit a startxref offset pointing into the middle of the xref table
+        // (e.g. past the 'xref' keyword line). The parseEntries scanner strips everything
+        // before the first 'xref' keyword it finds, so the extra prefix is harmless.
+        $expandedStart = max(0, $xrefPosition - 512);
+        $xrefText = substr($buffer, $expandedStart, $trailerPosition - $expandedStart);
         $xrefTable = $this->parseEntries($xrefText, $xrefPosition);
 
         $trailer = Trailer::new()
@@ -139,6 +151,30 @@ final class XRef14Parser
             // We store the entry by offset; the generation field is not used by the signer.
             $xrefTable[$objectId] = $offset;
         }
+    }
+
+    /**
+     * Scan backward from the end of the file for the last standalone `xref` keyword
+     * (preceded by a newline). Used when the startxref offset is stale/beyond EOF.
+     * Returns the byte offset of the `x` in `xref`, or null if not found.
+     */
+    private function findLastXrefByScanning(string $buffer): ?int
+    {
+        foreach (["\nxref\n", "\nxref\r\n", "\r\nxref\n", "\r\nxref\r\n"] as $needle) {
+            $pos = strrpos($buffer, $needle);
+            if ($pos !== false) {
+                return $pos + 1; // skip the leading newline; point at 'x'
+            }
+        }
+
+        // Also handle 'xref' at the very start of the buffer (no preceding newline).
+        foreach (["xref\n", "xref\r\n"] as $needle) {
+            if (str_starts_with($buffer, $needle)) {
+                return 0;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Infrastructure/PdfCore/PDFObjectTest.php
+++ b/tests/Infrastructure/PdfCore/PDFObjectTest.php
@@ -25,4 +25,46 @@ final class PDFObjectTest extends TestCase
 
         self::assertSame('abc', $object->getStream(false));
     }
+
+    /** @return array<string, array{callable, string}> */
+    public static function flateStreamEncodings(): array
+    {
+        return [
+            'zlib (RFC 1950) — conforming PDF generators' => [
+                static fn () => gzcompress('hello world'),
+                'hello world',
+            ],
+            'raw deflate (RFC 1951) — non-conforming generators, no wrapper header' => [
+                static fn () => gzdeflate('hello world'),
+                'hello world',
+            ],
+            'gzip (RFC 1952) — uncommon but encountered in the wild' => [
+                static fn () => gzencode('hello world'),
+                'hello world',
+            ],
+        ];
+    }
+
+    /**
+     * @param callable(): string $buildStream
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('flateStreamEncodings')]
+    public function test_get_stream_decodes_all_flate_encoding_variants(callable $buildStream, string $expected): void
+    {
+        $object = new PDFObject(1, ['Filter' => new PDFValueSimple('/FlateDecode')]);
+        $object->setStream($buildStream());
+
+        self::assertSame($expected, $object->getStream(false));
+    }
+
+    public function test_get_stream_throws_when_flate_stream_is_genuinely_corrupt(): void
+    {
+        $object = new PDFObject(1, ['Filter' => new PDFValueSimple('/FlateDecode')]);
+        $object->setStream("\x00\x01\x02\x03corrupt bytes");
+
+        $this->expectException(\SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException::class);
+        $this->expectExceptionMessage('Failed to inflate FlateDecode stream.');
+
+        $object->getStream(false);
+    }
 }

--- a/tests/Infrastructure/PdfCore/PDFObjectTest.php
+++ b/tests/Infrastructure/PdfCore/PDFObjectTest.php
@@ -46,7 +46,7 @@ final class PDFObjectTest extends TestCase
     }
 
     /**
-     * @param callable(): string $buildStream
+     * @param  callable(): string  $buildStream
      */
     #[\PHPUnit\Framework\Attributes\DataProvider('flateStreamEncodings')]
     public function test_get_stream_decodes_all_flate_encoding_variants(callable $buildStream, string $expected): void

--- a/tests/Infrastructure/PdfCore/Xref/Service/XRef14ParserTest.php
+++ b/tests/Infrastructure/PdfCore/Xref/Service/XRef14ParserTest.php
@@ -71,16 +71,34 @@ final class XRef14ParserTest extends TestCase
                 0,
                 15,
             ],
+            'xref position beyond EOF recovered by backward scan' => [
+                // startxref offset is stale/too large; backward scan locates the real xref table.
+                "xref\n0 1\n0000000010 00000 n \ntrailer\n<< /Size 1 >>\nstartxref\n99999\n%%EOF\n",
+                99999,
+                0,
+                10,
+            ],
+            'startxref offset points past xref keyword into table body (backward expansion)' => [
+                // Offset 5 is inside the xref table (after the "xref\n" keyword line at 0).
+                // The backward-expanded window (max 512 bytes) covers position 0 and finds it.
+                "xref\n0 1\n0000000010 00000 n \ntrailer\n<< /Size 1 >>\nstartxref\n5\n%%EOF\n",
+                5,
+                0,
+                10,
+            ],
         ];
     }
 
     /** @return array<string, array{string, int, string}> */
     public static function parseFailureCases(): array
     {
-        $validBuffer = "xref\n0 1\n0000000010 00000 n \ntrailer\n<< /Size 1 >>\n";
-
         return [
-            'xref position beyond end of file' => [$validBuffer, strlen($validBuffer) + 1, 'beyond end of file'],
+            'xref position beyond EOF and no xref table in buffer' => [
+                // No 'xref' keyword at all → backward scan finds nothing → throws.
+                "%PDF-1.4\nno xref content here\ntrailer\n<< /Size 1 >>\n",
+                9999,
+                'beyond end of file',
+            ],
             'xref tag missing at provided position' => [
                 "no-tag-here\ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n",
                 0,

--- a/tests/Infrastructure/PdfCore/Xref/XrefTest.php
+++ b/tests/Infrastructure/PdfCore/Xref/XrefTest.php
@@ -100,10 +100,13 @@ final class XrefTest extends TestCase
     public static function parseFailureCases(): array
     {
         return [
-            'xref position beyond end of file' => [
+            'xref position beyond end of file, backward scan recovers but trailer incomplete' => [
+                // startxref offset is beyond EOF; backward scan finds xref at position 0 and
+                // starts parsing, but the trailer dict has no 'startxref' token following it,
+                // causing Trailer::getTrailer() to fail.
                 "xref\n0 1\n0000000000 65535 f \ntrailer",
                 10_000,
-                'beyond end of file',
+                'Trailer not found.',
             ],
             'stream fallback for ambiguous content without trailer' => [
                 "garbage-at-start\n1 0 obj\n<< /Type /Catalog >>\nendobj\n",

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -37,7 +37,7 @@ final class StructTest extends TestCase
         self::assertSame(0, $structure->xrefPosition);
     }
 
-    public function test_parse_throws_when_startxref_is_missing(): void
+    public function test_parse_throws_when_neither_startxref_nor_xref_table_found(): void
     {
         $document = new PdfDocument;
         $document->setBufferFromString("%PDF-1.4\nno markers\n");
@@ -81,16 +81,53 @@ final class StructTest extends TestCase
             ->parse();
     }
 
-    public function test_parse_throws_when_final_startxref_block_is_malformed(): void
+    public function test_parse_throws_when_startxref_has_no_numeric_offset_and_no_xref_table(): void
     {
+        // 'startxref' present but carries no number and there is no fallback xref table.
         $document = new PdfDocument;
-        $document->setBufferFromString("%PDF-1.4\nstartxref\n10\nEOF\n");
+        $document->setBufferFromString("%PDF-1.4\nstartxref\n%%EOF\n");
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('startxref and %%EOF not found');
+        $this->expectExceptionMessage('startxref not found');
 
         Struct::new()
             ->withPdfDocument($document)
             ->parse();
+    }
+
+    public function test_parse_resolves_xref_when_startxref_has_offset_but_no_eof_marker(): void
+    {
+        // Lenient form: startxref carries a valid offset but %%EOF is missing (truncated file).
+        // The lenient regex should extract the offset and proceed.
+        $xrefBody = "xref\n0 1\n0000000010 00000 n \ntrailer\n<< /Size 1 >>\n";
+        $pdf = "%PDF-1.4\n" . $xrefBody . "startxref\n9\n";
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertSame('PDF-1.4', $structure->version);
+        self::assertSame(9, $structure->xrefPosition);
+    }
+
+    public function test_parse_recovers_xref_position_by_backward_scan_when_startxref_has_no_offset(): void
+    {
+        // 'startxref' present but carries no numeric offset (non-conforming generator).
+        // Both strict and lenient regexes fail; backward scan falls back to the xref table.
+        // Trailer.php can find "trailer...startxref" because the keyword exists in the buffer.
+        $xrefBody = "xref\n0 1\n0000000010 00000 n \ntrailer\n<< /Size 1 >>\nstartxref\n%%EOF\n";
+        $pdf = "%PDF-1.4\n" . $xrefBody;
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertSame('PDF-1.4', $structure->version);
+        // xrefPosition is the offset of the 'xref' keyword, right after the %PDF-1.4\n header (9 bytes).
+        self::assertSame(9, $structure->xrefPosition);
     }
 }

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -100,7 +100,7 @@ final class StructTest extends TestCase
         // Lenient form: startxref carries a valid offset but %%EOF is missing (truncated file).
         // The lenient regex should extract the offset and proceed.
         $xrefBody = "xref\n0 1\n0000000010 00000 n \ntrailer\n<< /Size 1 >>\n";
-        $pdf = "%PDF-1.4\n" . $xrefBody . "startxref\n9\n";
+        $pdf = "%PDF-1.4\n".$xrefBody."startxref\n9\n";
         $document = new PdfDocument;
         $document->setBufferFromString($pdf);
 
@@ -118,7 +118,7 @@ final class StructTest extends TestCase
         // Both strict and lenient regexes fail; backward scan falls back to the xref table.
         // Trailer.php can find "trailer...startxref" because the keyword exists in the buffer.
         $xrefBody = "xref\n0 1\n0000000010 00000 n \ntrailer\n<< /Size 1 >>\nstartxref\n%%EOF\n";
-        $pdf = "%PDF-1.4\n" . $xrefBody;
+        $pdf = "%PDF-1.4\n".$xrefBody;
         $document = new PdfDocument;
         $document->setBufferFromString($pdf);
 


### PR DESCRIPTION
This PR improves PDF core parsing robustness in malformed but recoverable files.

Changes:
- Added a FlateDecode fallback sequence (zlib, raw deflate, gzip).
- Improved startxref resolution with strict, lenient, and backward-scan strategies.
- Improved xref recovery when offsets are invalid or beyond EOF.
- Expanded xref parsing window to support mid-table offsets.
- Added regression tests for inflate fallbacks and xref/startxref recovery scenarios.